### PR TITLE
Military affidavit populates and court selector enables filing 

### DIFF
--- a/docassemble/MATCSmallClaims/data/questions/small_claims.yml
+++ b/docassemble/MATCSmallClaims/data/questions/small_claims.yml
@@ -103,9 +103,7 @@ code: |
   users[0].phone_number
   set_progress(28)
   set_parts(subtitle=str(users))
-  trial_court
   set_progress(14)
-  # docket_number
   attorneys.gather()
   if attorneys.number_gathered() > 0: 
     attorneys[0].address.address
@@ -121,6 +119,7 @@ code: |
   reason_for_suing_defendant
   nav.set_section("mediation")
   is_willing_mediation
+  trial_court
   set_progress(56)
   other_parties[0].is_current_military
   small_claims_preview_question 
@@ -182,15 +181,70 @@ subquestion: |
   
   If you cannot afford to pay your filing fee, you can ask the court to waive it by requesting it here [Fee Waiver](https://www.mass.gov/indigency-waiver-of-court-fees).
     
-  If you are a plaintiff, you can use this interview to file a statement of small claim and notice.
+  If you are a plaintiff, you can use this interview to file a statement of small claim and notice. 
+  
+  Please note that this interview cannot tell you what you should say to meet the legal basis needed for a judge to rule in your favor. The court can provide information about how to file a claim, but cannot give legal advice.
+  
+  There is a time limit on filing any claim in court. This is known as the statute of limitations. While there may be exceptions, generally:
+
+  - a claim based on a contract must be filed in court within 6 years,
+  - a claim based on a consumer protection law must be filed in court within 4 years, and
+  - a claim resulting from negligence or intentional harm must be filed in court within 3 years.
 
   Most people take about 15 minutes to complete this interview. 
+---
+id: your contact information
+question: |
+  What is your contact information?
+subquestion: |
+  Include at least **one** way to reach you other than by mail.
+
+  ${ collapse_template(why_contact_info_needed_template) }
+fields:  
+  - Mobile number: users[0].mobile_number
+    required: True
+  - Other phone number: users[0].phone_number
+    required: False
+  - Other ways to reach you: users[0].other_contact_method
+    input type: area
+    required: False
+    help: |
+      If you do not have a phone number or email, provide
+      specific contact instructions. For example, use a friend's phone number.
+      But the friend must be someone you can rely on to give you a
+      message.
+validation code: |
+  if (not showifdef('users[0].phone_number') and \
+      (not showifdef('users[0].mobile_number')) and \
+      (not showifdef('users[0].other_contact_method'))):
+    validation_error(word("You need to provide at least one contact method."), field="users[0].other_contact_method")
 ---
 id: Plaintiff s Claim
 question: |
   Plaintiff's Claim
 subquestion: |
-  Fill in the amount you are suing for and clearly state your claim so the defendant can understand why he or she is being sued. Provide the date of the event that is the basis of your claim. 
+  Fill in the amount you are suing for and clearly state your claim so the defendant can understand why he or she is being sued. Provide the date of the event that is the basis of your claim and requests for relief. This provides the Defendant with a breakdown of the amount being claimed and helps the court decide the amount of any award.
+  
+  Added penalties by statute:
+  If a law allows you to seek double or triple the amount of your claim, then you must include this specific information in your statement of claim. 
+
+  Added penalties by statute:
+  If a law allows you to seek double or triple the amount of your claim, then you must include this specific information in your statement of claim.
+  
+  What is a Small Claim?
+
+  A small claim is a legal process that is less complex than a traditional civil case. Your case will be heard by the Clerk-Magistrate or an Assistant Clerk-Magistrate of the Court -- not by a judge or jury. 
+  
+  The Uniform Small Claims Rues govern small claims cases. The procedure for bringing a small claim action can be found in the Massachusetts General Laws: [G.L c. 218, §§ 21-25](https://malegislature.gov/Laws/GeneralLaws/PartIII/TitleI/Chapter218/Section21) 
+
+  What is the maximum amount for a small claim?
+
+  The base amount you are suing for (including the value of property) must be $7,000 or less. There are two exceptions:
+  
+  1. If your claim is based on property damage from an automobile accident, the amount of your claim can be more than $7,000.
+  
+  2. If you are suing for unfair and deceptive practices under Chapter 93A, or under the Security Deposit Statute, the court may award additional damages above the $7,000 limit. The base amount of your claim must still be $7,000 or less.
+
 fields:
   
   - "Defendant owes amount": defendant_owes_amount
@@ -207,7 +261,10 @@ id: Additional Information
 question: |
   Are you willing to attempt to settle this claim through mediation?
 subquestion: | 
-  The mediator will assist the parties in trying to resolve the dispute on mutually agreed terms. The Plaintiff must notify the court if he or she desires mediation. The defendant may consent to mediation on the trial date. 
+  Mediation is when all parties in a lawsuit sit down with a neutral person who helps them discuss the case and tries to negotiate a settlement or resolution.
+  
+  
+  The Plaintiff must notify the court if he or she desires mediation. The defendant may consent to mediation on the trial date. You do not lose your right to a trial if you go to mediation and it is unsuccessful.
   
 fields:
   - "Are you willing to mediate?": is_willing_mediation
@@ -240,13 +297,20 @@ subquestion: |
   - the rental property is located (if you are filing a claim about a landlord-tenant issue).
 
 ---
-# id: who will be on this form
-# generic object: ALPeopleList
-# question: |
-#  Will this form include any ${noun_plural(x.object_name())}?
-# fields:
-#  - no label: x.there_are_any
-#    datatype: yesnoradio
+ id: who will be on this form
+ generic object: ALPeopleList
+ question: |
+  Will this form include any ${noun_plural(x.object_name())}?
+ subquestion: | 
+  You do not need an attorney to go to court on a small claims case, but you may hire one if you wish. 
+  
+  The court will not provide an attorney for you. 
+  
+  If you want to find an attorney, you can use the [Massachusetts Legal Resource Finder](www.massLRF.org) or your local bar association's lawyer referral service.
+
+ fields:
+  - no label: x.there_are_any
+    datatype: yesnoradio
 ---
 id: name of the first person
 sets:
@@ -277,6 +341,15 @@ question: |
   % else:
   Name of ${ ordinal(i) } **plaintiff** or petitioner in this matter
   % endif
+subquestion: | 
+  To find the exact legal name and address of a corporation, visit the Corporate Records Division of the Secretary of State’s Office website by clicking [here](https://corp.sec.state.ma.us/corpweb/CorpSearch/CorpSearch.aspx)
+  
+  If the Plaintiff or Defendant is not a corporation and is doing business under a trade name ("doing business as," or d/b/a): 
+
+  Verify the name by calling the city or town hall where the business is located.
+
+  Any entity that does business under a trade name is required to register in the local city or town clerk's office where the business is located.
+
 fields:
   - "Does ${other_parties[0]} currently serve in the military?": other_parties[0].is_current_military
     datatype: yesnomaybe
@@ -301,7 +374,12 @@ id: Military Affidavit
 question: | 
   Is ${other_parties[0]} in the military?
 subquestion: |
+  If you know the defendant’s social security number or birth date, you may determine whether he or she is on active military duty online at the [SCRA Website](https://scra.dmdc.osd.mil/scra/#/home). 
+  
+   If you are unable to determine whether the defendant is on active military duty and the defendant fails to appear, the court may require you to post a bond or may issue other orders to protect the rights of the defendant if he or she is on active military duty.
+  
   Pursuant to the Service Members Civil Relief Act 50 USC §3931, you state under the pains and penalties of perjury that: 
+  
 fields:
   - "Does ${other_parties[0]} currently serve in the military?": other_parties[0].is_current_military
     datatype: yesnomaybe
@@ -338,11 +416,22 @@ id: small claims review screen
 event: review_small_claims
 question: |
   Review your answers
+subquestion: |
+  Depending on where you have chosen to file, you may have the option to eFile your forms after you have reviewed them and paid the filing fee.
+
+  If you do not have the option to eFile, print the completed forms. You may bring or mail the completed form, along with the filing fee, to the Clerk-Magistrate's office of the court where you are filing your case. The filing fee can be paid by cash, credit card, or check or money order made payable to the court.
+
+  Once you have filed your claim you will be assigned a hearing date in court. Cases will be heard by the Clerk-Magistrate or an Assistant Clerk-Magistrate of the Court.
+
+  If you will be submitting documents or other exhibits when you come to court, make sure that you bring extra sets to your hearing: one for the Clerk-Magistrate and one for each Defendant.
+
+  As the Plaintiff, you will be required to appear at all scheduled court dates, or the case may be dismissed by the court.
+
+  Once you have filed the case in court, it is your responsibility as the Plaintiff to notify the court if you and the Defendant(s) resolve the case outside of court. You may be required to file a document in writing to officially close or dispose of the case.
+
+  If the Defendant(s) does not come to the hearing, the Clerk-Magistrate may still require you to prove the value of the damages that you have submitted in your claim. You should be prepared to provide evidence on damages any time you are scheduled to be in court.
+  
 review:
-#  - Edit: docket_number
-#    button: |
-#      **Docket number**:
-#      ${ docket_number }
   - Edit: municipal_court
     button: |
       **Municipal court**:
@@ -553,7 +642,6 @@ attachment:
   skip undefined: True
   pdf template file: small_claims.pdf
   fields:
-      # - "docket_number": ${ docket_number }
       - "bmc": | 
              % if trial_court.department == "Boston Municipal Court": 
              ${ trial_court.division } 

--- a/docassemble/MATCSmallClaims/data/questions/small_claims.yml
+++ b/docassemble/MATCSmallClaims/data/questions/small_claims.yml
@@ -99,6 +99,9 @@ code: |
   user_role = "plaintiff"
   user_ask_role = "plaintiff"
   users.gather()  
+  users[0].address.address
+  users[0].phone_number
+  set_progress(28)
   set_parts(subtitle=str(users))
   trial_court
   set_progress(14)
@@ -107,9 +110,6 @@ code: |
   if attorneys.number_gathered() > 0: 
     attorneys[0].address.address
     attorneys[0].phone_number
-  set_progress(28)
-  users[0].address.address
-  users[0].phone_number
   set_progress(42)
   other_parties.gather()
   defendants
@@ -300,9 +300,13 @@ fields:
 id: Military Affidavit
 question: | 
   Is ${other_parties[0]} in the military?
+subquestion: |
+  Pursuant to the Service Members Civil Relief Act 50 USC §3931, you state under the pains and penalties of perjury that: 
 fields:
   - "Does ${other_parties[0]} currently serve in the military?": other_parties[0].is_current_military
     datatype: yesnomaybe
+  - "Required facts in support of military affidavit": military_affidavit_facts
+    input type: area
 ---
 id: preview small_claims
 question: |
@@ -420,6 +424,10 @@ review:
     button: |
       **Is current military**:
       ${ is_current_military }
+  - Edit: Military_affidavit_facts
+    button: |
+      **Military affidavit facts**
+      ${ Military_affidavit_facts }
 ---
 continue button field: attorneys.revisit
 question: |
@@ -589,3 +597,4 @@ attachment:
       - "current_military_defendant": ${ defendants.filter(is_current_military = True) }
       - "unknown_current_military": ${ any([person.is_current_military is None for person in defendants])}
       - "is_current_military": ${ any([person.is_current_military for person in defendants])}
+      - "military_affidavit_facts": ${ military_affidavit_facts }

--- a/docassemble/MATCSmallClaims/data/questions/small_claims.yml
+++ b/docassemble/MATCSmallClaims/data/questions/small_claims.yml
@@ -513,10 +513,10 @@ review:
     button: |
       **Is current military**:
       ${ is_current_military }
-  - Edit: Military_affidavit_facts
+  - Edit: military_affidavit_facts
     button: |
-      **Military affidavit facts**
-      ${ Military_affidavit_facts }
+      **military affidavit facts**
+      ${ military_affidavit_facts }
 ---
 continue button field: attorneys.revisit
 question: |

--- a/docassemble/MATCSmallClaims/data/questions/small_claims.yml
+++ b/docassemble/MATCSmallClaims/data/questions/small_claims.yml
@@ -306,7 +306,7 @@ subquestion: |
   
   The court will not provide an attorney for you. 
   
-  If you want to find an attorney, you can use the [Massachusetts Legal Resource Finder](www.massLRF.org) or your local bar association's lawyer referral service.
+  If you want to find an attorney, you can use the [Massachusetts Legal Resource Finder](https://masslrf.org/en/home) or your local bar association's lawyer referral service.
 
  fields:
   - no label: x.there_are_any
@@ -326,12 +326,15 @@ question: |
   % else:
   Name of your first ${ noun_plural(x.object_name(),1) }
   % endif
+subquestion: |
+  Please [click here](https://www.massbbo.org/bbolookup.php) to look up your BBO number.
 fields:
   - code: |
       x[0].name_fields()
   - "Bbo number": bbo_number
     maxlength: 6
     required: True
+
 ---
 id: names of opposing parties
 question: |


### PR DESCRIPTION
court selector allows user to file in 3 options: their own location, defendants location, or location of incident. 
military affidavit populates with users 
added descriptive text and links for user  