### PR TITLE
Update additional business info to show up conditionally

### DIFF
--- a/docassemble/MATCSmallClaims/data/questions/small_claims.yml
+++ b/docassemble/MATCSmallClaims/data/questions/small_claims.yml
@@ -760,20 +760,13 @@ fields:
       variable: other_parties[i].person_type
       is: person
 
-  - field: other_parties[i].name.suffix
-    label: Suffix
-    choices:
-      - "Jr."
-      - "Sr."
-      - "II"
-      - "III"
-      - "IV"
-      - "V"
-      - "VI"
+  - Suffix: other_parties[i].name.suffix
     required: False
     show if: 
       variable: other_parties[i].person_type
       is: person
+    code: |
+      name_suffix()
 
   - field: other_parties[i].name.first
     label: Name of business or organization


### PR DESCRIPTION
Only show the information about business names if the user selects "Business or organization" on the "names of opposing" parties screen. Also moves the text to below the radio buttons.

New screens:

<img width="580" alt="image" src="https://github.com/user-attachments/assets/b9af9f8e-1a20-4e03-bdc3-0c90226b70ff">

<img width="601" alt="image" src="https://github.com/user-attachments/assets/ac527ab5-400e-46b1-bb29-52d6b0c156b6">



Closes #79 