### PR TITLE
Display military_affidavit_facts only if yes

### DIFF
--- a/docassemble/MATCSmallClaims/data/questions/small_claims.yml
+++ b/docassemble/MATCSmallClaims/data/questions/small_claims.yml
@@ -835,10 +835,12 @@ fields:
     datatype: yesno
     js show if: |
       val("other_parties[i].is_current_military") === "None"
-  - "How do you know ${other_parties[i]}'s military status?": other_parties[i].military_affidavit_facts
+  - "If yes, how do you know?": other_parties[i].military_affidavit_facts
     input type: area
     maxlength: 1395
-    hide if: still_unsure
+    show if:
+      variable: other_parties[i].is_current_military
+      is: True
   - "Why is it that you don't know ${other_parties[i]}'s military status?": other_parties[i].military_affidavit_facts
     input type: area
     maxlength: 1395

--- a/docassemble/MATCSmallClaims/data/questions/small_claims.yml
+++ b/docassemble/MATCSmallClaims/data/questions/small_claims.yml
@@ -114,7 +114,6 @@ code: |
   other_parties[0].address.address
   other_parties[0].phone_number
   other_parties[0].is_current_military
-  other_parties[0].military_affidavit_facts
   trial_court.department
   nav.set_section("plaintiff_s_claim")
   defendant_owes_amount
@@ -844,7 +843,8 @@ fields:
   - "Why is it that you don't know ${other_parties[i]}'s military status?": other_parties[i].military_affidavit_facts
     input type: area
     maxlength: 1395
-    show if: still_unsure
+    js show if: | 
+      val("still_unsure") == true && val("other_parties[i].is_current_military") === "None"
   - note: |
       The court may require you to post a bond or may issue other orders to protect the rights of the defendant if they are on active military duty.
     show if: still_unsure


### PR DESCRIPTION
The military_affidavit_facts was being displayed both when a user selected yes and no. The box now displays only when the user selects yes.

**Base**
<img width="411" alt="image" src="https://github.com/user-attachments/assets/0bc34ef4-4ea4-425b-9ace-b086eb70e61e">

**Yes**
<img width="404" alt="image" src="https://github.com/user-attachments/assets/3712095a-9d1f-4060-9ca7-d87f8a2a3425">

**No**
<img width="409" alt="image" src="https://github.com/user-attachments/assets/4cdcf9a2-d311-4181-9a71-402229bb3ef6">

**I don't know**
<img width="402" alt="image" src="https://github.com/user-attachments/assets/e464928b-33ce-4abc-af1d-e28689d6be80">

Closes #80
