### PR TITLE
Fix ordering of sections

### DIFF
--- a/docassemble/MATCSmallClaims/data/questions/small_claims.yml
+++ b/docassemble/MATCSmallClaims/data/questions/small_claims.yml
@@ -70,9 +70,8 @@ objects:
 ---
 sections:
   - plaintiff_question: Plaintiff information
-  - court_selection: Court selection
-  - attorney_question: Attorney information
   - defendant_question: Defendant information
+  - court_selection: Court selection
   - plaintiff_s_claim: Your claim
   - mediation: Mediation
   - wants_fee_waiver: Fee Waiver
@@ -85,8 +84,9 @@ id: interview_order_small_claims
 code: |
   # Set the allowed courts for this interview
   allowed_courts = ['District Court', 'Boston Municipal Court', 'Housing Court']
-  nav.set_section("preliminary_information")
+
   small_claims_intro
+
   al_person_answering
   if al_person_answering == "attorney":
     attorneys.there_are_any = True
@@ -94,40 +94,47 @@ code: |
     attorneys.there_are_any = False
   users.gather()
   if users.number_gathered() > 0:
+    nav.set_section("plaintiff_question")
     users[0].address.address
     users[0].phone_number
   set_progress(28)
   set_parts(subtitle=str(users))
-  nav.set_section("court_selection")
-  set_parts(subtitle=str(users))
-  set_progress(14)
-  # docket_number
-  nav.set_section("attorney_question")
+    
   attorneys.gather()
   if attorneys.number_gathered() > 0: 
+    nav.set_section("attorney_question")
     attorneys[0].address.address
     attorneys[0].phone_number
   set_progress(42)
-  nav.set_section("defendant question")
+
+  nav.set_section("defendant_question")
   other_parties.gather()
   defendants
   other_parties[0].address.address
   other_parties[0].phone_number
   other_parties[0].is_current_military
-  other_parties[0].military_affidavit_facts
+
+  nav.set_section("court_selection")
+  set_parts(subtitle=str(users))
+  set_progress(14)
+  # docket_number
   trial_court.department
+  
   nav.set_section("plaintiff_s_claim")
   defendant_owes_amount
   filing_fee
   reason_for_suing_defendant
+
   nav.set_section("mediation")
   is_willing_mediation
   trial_court
   set_progress(56)
+
   nav.set_section("wants_fee_waiver")
-  if wants_fee_waiver: 
+  if wants_fee_waiver:
     is_indigent
     set_fee_waiver_defaults
+
   nav.set_section("review_small_claims")
   users[0].states_above_true
   interview_order_small_claims = True


### PR DESCRIPTION
* Fixes the ordering of the sections. 
* Added newlines in between sections to improve readability.
* May cause merge conflict with #101. An important part while merging is to ensure the line `other_parties[0].military_affidavit_facts` remains absent from the interview order.


Closes #103